### PR TITLE
refine: change default debounce time to 600ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jimengio/jimo-ui",
-  "version": "0.1.0",
+  "version": "0.1.1-a1",
   "description": "",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/work/debounced-input.tsx
+++ b/src/work/debounced-input.tsx
@@ -5,7 +5,7 @@ import Input, { InputProps } from "antd/lib/input";
 import JimoIcon, { EJimoIcon } from "@jimengio/jimo-icons";
 
 export interface DebouncedInputProps extends InputProps {
-  /** defaults to 300 */
+  /** defaults to 600 */
   wait?: number;
   /** defaults to { width: 220px } */
   style?: CSSProperties;
@@ -16,7 +16,7 @@ export interface DebouncedInputProps extends InputProps {
 }
 
 const defaultProps: Partial<DebouncedInputProps> = {
-  wait: 300,
+  wait: 600,
   style: { width: 220 },
 };
 


### PR DESCRIPTION
统一为 600ms, 前面的 300ms 对输入来说不友好.
